### PR TITLE
Silenced the "Dearhal-specific bug" on Admin chat

### DIFF
--- a/src/main/java/me/Seisan/plugin/Features/Chat/ChatFormat.java
+++ b/src/main/java/me/Seisan/plugin/Features/Chat/ChatFormat.java
@@ -1020,6 +1020,8 @@ public class ChatFormat extends Feature {
         for (int i = 0; i < messageCopied.length; i++) {
             // on hover, we replace the hover action containing {PLAYER-DATA} by the relative quadrant direction of the player compared to p
             if (messageCopied[i].getHoverEvent() != null && messageCopied[i].getHoverEvent().getAction().equals(HoverEvent.Action.SHOW_TEXT)) {
+                BaseComponent nameWithHover = new TextComponent();
+                if (messageCopied[i].getExtra() != null) messageCopied[i].getExtra().forEach(nameWithHover::addExtra);
                 for (BaseComponent baseComponent : messageCopied[i].getHoverEvent().getValue()) {
                     if (baseComponent instanceof TextComponent) {
                         TextComponent textComponent = (TextComponent) baseComponent;
@@ -1028,8 +1030,8 @@ public class ChatFormat extends Feature {
                             //Rebuild from scratch this part without the informations of the class
                             //zuper
 
-                            BaseComponent nameWithHover = new TextComponent();
-                            messageCopied[i].getExtra().forEach(nameWithHover::addExtra);
+
+
                             nameWithHover.setHoverEvent(
                                     new HoverEvent(
                                             HoverEvent.Action.SHOW_TEXT,


### PR DESCRIPTION
This pull request includes changes to the `sendFinalMessage` method in the `ChatFormat` class to fix a potential null pointer exception.

The null pointer is not longer thrown, but Daerhal's account is not able to see the names of the messages' sender. Which makes perfect sens when you look at the code, but everyone else is able to see them. Sooo idk. Let's roll with that, and will work fast on the real "Ninkai plugin".
